### PR TITLE
Resolve issue request 48

### DIFF
--- a/src/webparts/trackMyTime/components/ActivityURL/GithubRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/GithubRules.ts
@@ -7,101 +7,101 @@ export const github : ISmartLinkDef = {
     rules: [
         {
             order: 100,
-            title: "Github Issue ",  // Rule title
+            ruleTitle: "Github Issue ",  // Rule title
 
             keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
-            childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
+            childFolderTitle: '#...x...', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
-            parentFolderTitle: '^^^really ...x... long word ', // use 'na' to skip this rule.  '' to have no Title
-            parent2FolderTitle: 'U...x...ser: ', // use 'na' to skip this rule.  '' to have no Title
+            parentFolderTitle: '^^^...x..., ', // use 'na' to skip this rule.  '' to have no Title
+            parent2FolderTitle: '...x...', // use 'na' to skip this rule.  '' to have no Title
 
-            commentTextMapping: 'title, parent2FolderTitle, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: 'childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: 'The Cat raised issue: childFolderTitle on parentFolderTitle and parent2FolderTitle resolved it with PR 46!', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: 'childFolderTitle, parentFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title, parentFolderTitle',
-            projectID1Mapping: 'parentFolderTitle, title',
+            category2Mapping: 'ruleTitle, parentFolderTitle',
+            projectID1Mapping: 'parentFolderTitle, ruleTitle',
             projectID2Mapping: 'childFolderTitle, parent2FolderTitle',
 
         },        {
             order: 100,
-            title: "Github Pull Request",  // Rule title
+            ruleTitle: "Github Pull Request",  // Rule title
             keyFolder: '/pull/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: 'User: ', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: 'ruleTitle, childFolderTitle, parentFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: 'childFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "Github Branch",  // Rule title
+            ruleTitle: "Github Branch",  // Rule title
             keyFolder: '/tree/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' ...x..., ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: 'User: ', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: 'ruleTitle, childFolderTitle, parentFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: 'childFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "Github Project",  // Rule title
+            ruleTitle: "Github Project",  // Rule title
             keyFolder: '/projects/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: '', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: 'User: ', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: '', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: '', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: '',
             projectID2Mapping: '',
         },        {
             order: 100,
-            title: "Github Wiki",  // Rule title
+            ruleTitle: "Github Wiki",  // Rule title
             keyFolder: '/wiki', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: 'Page: ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: 'User: ', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: '', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: '', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: '',
             projectID2Mapping: '',
         },        {
             order: 100,
-            title: "Github Commit",  // Rule title
+            ruleTitle: "Github Commit",  // Rule title
             keyFolder: '/commit/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' #...x...,<<8<< ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: 'User: ', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: 'title, childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: '', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: 'ruleTitle, childFolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "",  // Rule title
+            ruleTitle: "",  // Rule title
             keyFolder: '/blob/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' in \'...x...\' Branch,', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: ' File: ', // use 'na' to skip this rule.  '' to have no Title
             parentFolderTitle: ' ^^^Repo: ...x...,', // use 'na' to skip this rule.  '' to have no Title
             parent2FolderTitle: ' from User: ...x...:', // use 'na' to skip this rule.  '' to have no Title
-            commentTextMapping: 'title, parentFolderTitle, childFolderTitle, keyFolder', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
-            activityDescMapping: 'title, parentFolderTitle, child2FolderTitle, childFolderTitle, parent2FolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            commentTextMapping: 'ruleTitle, parentFolderTitle, childFolderTitle, keyFolder', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
+            activityDescMapping: 'ruleTitle, parentFolderTitle, child2FolderTitle, childFolderTitle, parent2FolderTitle', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'child2FolderTitle',
             category2Mapping: 'childFolderTitle',
             projectID1Mapping: 'parentFolderTitle',

--- a/src/webparts/trackMyTime/components/ActivityURL/JiraRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/JiraRules.ts
@@ -5,7 +5,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
  * Example from github 
  * {
     order: 100,
-    title: "Github Issue ",  // Rule title
+    ruleTitle: "Github Issue ",  // Rule title
 
     keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
     childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
@@ -16,7 +16,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
     commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     category1Mapping: 'parentFolderTitle',
-    category2Mapping: 'title',
+    category2Mapping: 'ruleTitle',
     projectID1Mapping: 'parentFolderTitle',
     projectID2Mapping: 'childFolderTitle',
  * }

--- a/src/webparts/trackMyTime/components/ActivityURL/ModelRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/ModelRules.ts
@@ -5,7 +5,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
  * Example from github 
  * {
     order: 100,
-    title: "Github Issue ",  // Rule title
+    ruleTitle: "Github Issue ",  // Rule title
 
     keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
     childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
@@ -16,7 +16,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
     commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     category1Mapping: 'parentFolderTitle',
-    category2Mapping: 'title',
+    category2Mapping: 'ruleTitle',
     projectID1Mapping: 'parentFolderTitle',
     projectID2Mapping: 'childFolderTitle',
  * }

--- a/src/webparts/trackMyTime/components/ActivityURL/OriginalRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/OriginalRules.ts
@@ -7,7 +7,7 @@ export const github : ISmartLinkDef = {
     rules: [
         {
             order: 100,
-            title: "Github Issue ",  // Rule title
+            ruleTitle: "Github Issue ",  // Rule title
 
             keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
@@ -18,13 +18,13 @@ export const github : ISmartLinkDef = {
             commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
 
         },        {
             order: 100,
-            title: "Github Pull Request",  // Rule title
+            ruleTitle: "Github Pull Request",  // Rule title
             keyFolder: '/pull/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
@@ -33,12 +33,12 @@ export const github : ISmartLinkDef = {
             commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "Github Branch",  // Rule title
+            ruleTitle: "Github Branch",  // Rule title
             keyFolder: '/tree/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' ...x..., ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
@@ -47,12 +47,12 @@ export const github : ISmartLinkDef = {
             commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "Github Project",  // Rule title
+            ruleTitle: "Github Project",  // Rule title
             keyFolder: '/projects/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: '', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
@@ -61,12 +61,12 @@ export const github : ISmartLinkDef = {
             commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: '',
             projectID2Mapping: '',
         },        {
             order: 100,
-            title: "Github Wiki",  // Rule title
+            ruleTitle: "Github Wiki",  // Rule title
             keyFolder: '/wiki', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: 'Page: ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
@@ -75,12 +75,12 @@ export const github : ISmartLinkDef = {
             commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: '',
             projectID2Mapping: '',
         },        {
             order: 100,
-            title: "Github Commit",  // Rule title
+            ruleTitle: "Github Commit",  // Rule title
             keyFolder: '/commit/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' #...x...,<<8<< ', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: 'na', // use 'na' to skip this rule.  '' to have no Title
@@ -89,12 +89,12 @@ export const github : ISmartLinkDef = {
             commentTextMapping: '', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             activityDescMapping: 'title, childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
             category1Mapping: 'parentFolderTitle',
-            category2Mapping: 'title',
+            category2Mapping: 'ruleTitle',
             projectID1Mapping: 'parentFolderTitle',
             projectID2Mapping: 'childFolderTitle',
         },        {
             order: 100,
-            title: "",  // Rule title
+            ruleTitle: "",  // Rule title
             keyFolder: '/blob/', // Key folder in URL to apply rule too ( like /issues/ )
             childFolderTitle: ' in \'...x...\' Branch,', // use 'na' to skip this rule.  '' to have no Title
             child2FolderTitle: ' File: ', // use 'na' to skip this rule.  '' to have no Title

--- a/src/webparts/trackMyTime/components/ActivityURL/ServiceNowRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/ServiceNowRules.ts
@@ -5,7 +5,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
  * Example from github 
  * {
     order: 100,
-    title: "Github Issue ",  // Rule title
+    ruleTitle: "Github Issue ",  // Rule title
 
     keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
     childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
@@ -16,7 +16,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
     commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     category1Mapping: 'parentFolderTitle',
-    category2Mapping: 'title',
+    category2Mapping: 'ruleTitle',
     projectID1Mapping: 'parentFolderTitle',
     projectID2Mapping: 'childFolderTitle',
  * }

--- a/src/webparts/trackMyTime/components/ActivityURL/SharePointOnlineRules.ts
+++ b/src/webparts/trackMyTime/components/ActivityURL/SharePointOnlineRules.ts
@@ -5,7 +5,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
  * Example from github 
  * {
     order: 100,
-    title: "Github Issue ",  // Rule title
+    ruleTitle: "Github Issue ",  // Rule title
 
     keyFolder: '/issues/', // Key folder in URL to apply rule too ( like /issues/ )
     childFolderTitle: '#...x..., ', // use 'na' to skip this rule.  '' to have no Title
@@ -16,7 +16,7 @@ import { ITrackMyTimeProps } from '../ITrackMyTimeProps';
     commentTextMapping: 'title, childFolderTitle, parentFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     activityDescMapping: 'childFolderTitle', // "title, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up
     category1Mapping: 'parentFolderTitle',
-    category2Mapping: 'title',
+    category2Mapping: 'ruleTitle',
     projectID1Mapping: 'parentFolderTitle',
     projectID2Mapping: 'childFolderTitle',
  * }

--- a/src/webparts/trackMyTime/components/fields/textFieldBuilder.tsx
+++ b/src/webparts/trackMyTime/components/fields/textFieldBuilder.tsx
@@ -186,7 +186,7 @@ import {
       return createBasicTextField(field, currentValue, onChanged, blinkOnProjectClassName);
 
     }  else if (field.type === "SmartLink") {
-      let currentValue = parentState.formEntry[field.name];
+      let currentValue = parentState.formEntry[field.name]['url'];
       let blinkOnProjectClassName = getBlinkOnProjectClass(field, parentState.blinkOnProject);
 
       return createSmartLinkField(field, currentValue, onChanged, blinkOnProjectClassName);


### PR DESCRIPTION
Now you can use the ILinkRule Title properties directly in the Mapping ones.

example:

## syntax had to be:
commentTextMapping: 'ruleTitle, childFolderTitle, parentFolderTitle',

## syntax now is:
            commentTextMapping: 'The Cat raised issue: childFolderTitle on parentFolderTitle and parent2FolderTitle resolved it with PR 46!', // "ruleTitle, parentFolderTitle, keyFolder, childFolderTitle" - properties from this interface to build up

## Verification
![image](https://user-images.githubusercontent.com/49648086/71697825-3d452d00-2d87-11ea-8b7a-25fb880e6a79.png)
